### PR TITLE
Enable AutomountServiceAccountToken when injecting proxy

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -611,6 +611,9 @@ func (conf *ResourceConfig) injectObjectMeta(patch *Patch) {
 		patch.addPodAnnotationsRoot()
 	}
 	patch.addPodAnnotation(k8s.ProxyVersionAnnotation, conf.configs.GetGlobal().GetVersion())
+	if conf.pod.spec.AutomountServiceAccountToken != nil && *conf.pod.spec.AutomountServiceAccountToken == false {
+		patch.addPodAnnotation(k8s.AutomountServiceAccountTokenAnnotation, k8s.AutomountServiceAccountTokenEnabled)
+	}
 
 	if conf.configs.GetGlobal().GetIdentityContext() != nil {
 		patch.addPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeDefault)

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -391,6 +391,11 @@ func (conf *ResourceConfig) complete(template *v1.PodTemplateSpec) {
 
 // injectPodSpec adds linkerd sidecars to the provided PodSpec.
 func (conf *ResourceConfig) injectPodSpec(patch *Patch) {
+	// check whether pod has auto-mounting of service account token disabled; without it the proxy won't start
+	if conf.pod.spec.AutomountServiceAccountToken != nil && *conf.pod.spec.AutomountServiceAccountToken == false {
+		patch.enableAutomountServiceAccountToken()
+	}
+
 	saVolumeMount := conf.serviceAccountVolumeMount()
 	if !conf.configs.GetGlobal().GetCniEnabled() {
 		conf.injectProxyInit(patch, saVolumeMount)

--- a/pkg/inject/patch.go
+++ b/pkg/inject/patch.go
@@ -22,6 +22,8 @@ type Patch struct {
 	patchPathVolume            string
 	patchPathPodLabels         string
 	patchPathPodAnnotations    string
+
+	patchPathEnableAutomountServiceAccountToken string
 }
 
 // NewPatch returns a new instance of Patch for any kind of workload kind
@@ -36,6 +38,8 @@ func NewPatch(kind string) *Patch {
 			patchPathVolume:            "/spec/volumes/-",
 			patchPathPodLabels:         patchPathRootLabels,
 			patchPathPodAnnotations:    "/metadata/annotations",
+
+			patchPathEnableAutomountServiceAccountToken: "/spec/automountServiceAccountToken",
 		}
 	}
 
@@ -48,6 +52,8 @@ func NewPatch(kind string) *Patch {
 		patchPathVolume:            "/spec/template/spec/volumes/-",
 		patchPathPodLabels:         "/spec/template/metadata/labels",
 		patchPathPodAnnotations:    "/spec/template/metadata/annotations",
+
+		patchPathEnableAutomountServiceAccountToken: "/spec/template/spec/automountServiceAccountToken",
 	}
 }
 
@@ -126,6 +132,14 @@ func (p *Patch) addPodAnnotation(key, value string) {
 		Op:    "add",
 		Path:  p.patchPathPodAnnotations + "/" + escapeKey(key),
 		Value: value,
+	})
+}
+
+func (p *Patch) enableAutomountServiceAccountToken() {
+	p.patchOps = append(p.patchOps, &patchOp{
+		Op:    "add",
+		Path:  p.patchPathEnableAutomountServiceAccountToken,
+		Value: true,
 	})
 }
 

--- a/pkg/inject/patch_test.go
+++ b/pkg/inject/patch_test.go
@@ -41,6 +41,7 @@ func TestPatch(t *testing.T) {
 	actual.addVolume(secrets)
 	actual.addPodLabel(k8sPkg.ControllerNSLabel, controllerNamespace)
 	actual.addPodAnnotation(k8sPkg.CreatedByAnnotation, createdBy)
+	actual.enableAutomountServiceAccountToken()
 
 	expected := NewPatch(k8sPkg.Deployment)
 	expected.patchOps = []*patchOp{
@@ -51,6 +52,7 @@ func TestPatch(t *testing.T) {
 		{Op: "add", Path: expected.patchPathVolume, Value: secrets},
 		{Op: "add", Path: expected.patchPathPodLabels + "/" + escapeKey(k8sPkg.ControllerNSLabel), Value: controllerNamespace},
 		{Op: "add", Path: expected.patchPathPodAnnotations + "/" + escapeKey(k8sPkg.CreatedByAnnotation), Value: createdBy},
+		{Op: "add", Path: expected.patchPathEnableAutomountServiceAccountToken, Value: true},
 	}
 
 	if !reflect.DeepEqual(actual, expected) {

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -29,6 +29,12 @@ func (conf *ResourceConfig) Uninject(report *Report) ([]byte, error) {
 // and init-container uninjected
 func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
 	t := conf.pod.spec
+
+	if conf.pod.meta.Annotations[k8s.AutomountServiceAccountTokenAnnotation] == k8s.AutomountServiceAccountTokenEnabled {
+		var disableAutomountServiceAccountToken bool
+		t.AutomountServiceAccountToken = &disableAutomountServiceAccountToken
+	}
+
 	initContainers := []v1.Container{}
 	for _, container := range t.InitContainers {
 		if container.Name != k8s.InitContainerName {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -86,6 +86,14 @@ const (
 	// in service identity.
 	IdentityModeAnnotation = Prefix + "/identity-mode"
 
+	// AutomountServiceAccountTokenAnnotation is set to indicate that the
+	// proxy injector had to enable AutomountServiceAccountToken on the pod
+	AutomountServiceAccountTokenAnnotation = Prefix + "/automount-service-account-token"
+
+	// AutomountServiceAccountTokenEnabled denotes the only value the
+	// AutomountServiceAccountTokenAnnotation can have if it's set.
+	AutomountServiceAccountTokenEnabled = "enabled"
+
 	/*
 	 * Proxy config annotations
 	 */


### PR DESCRIPTION
This enables `AutomountServiceAccountToken` when injecting the proxy sidecar into pods. With a little bit more work (an integration test would be nice, I did add some tests but I'm not sure this really works) we could upstream this. Security caveats apply of course. The linkerd folks might want to prevent injection altogether if the injector sees that the option is disabled.

Let's see if we can build the controller image (the injector's image is `gcr.io/linkerd-io/controller:stable-2.3.0`) tomorrow and take it for a spin.